### PR TITLE
Bolderize button now unbolderize bold text.

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,5 +2,6 @@ module.exports = {
     "transform": {
         "^.+\\.[t|j]sx?$": "babel-jest"
     },
-    "testEnvironment": "jsdom"
+    "testEnvironment": "jsdom",
+    "transformIgnorePatterns": [],
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "social-styled-text",
       "version": "1.0.0",
       "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
       "devDependencies": {
         "@babel/core": "^7.18.13",
         "@babel/plugin-transform-modules-commonjs": "^7.18.6",
@@ -4970,7 +4973,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -9526,8 +9528,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "querystringify": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
     "jest": "^29.0.1",
     "jest-environment-jsdom": "^29.0.1",
     "sinon-chrome": "^3.0.1"
+  },
+  "dependencies": {
+    "punycode": "^2.1.1"
   }
 }

--- a/ui/popup.js
+++ b/ui/popup.js
@@ -1,4 +1,4 @@
-import {bolderizeWord} from "../utils/bolderizeWord.js";
+import {bolderizeOrUnbolderizeWord} from "../utils/bolderizeWord.js";
 
 function getSelectionText() {
     return window.getSelection().toString();
@@ -22,7 +22,7 @@ button.addEventListener('click', () => {
             target: {tabId},
             func: getSelectionText
         }, function(results) {
-            const boldValues = bolderizeWord(results[0].result);
+            const boldValues = bolderizeOrUnbolderizeWord(results[0].result);
             chrome.scripting.executeScript( {
                 target: {tabId},
                 func: modifySelection,

--- a/utils/bolderizeWord.js
+++ b/utils/bolderizeWord.js
@@ -1,18 +1,57 @@
-const upperDiff = "𝗔".codePointAt(0) - "A".codePointAt(0);
-const lowerDiff = "𝗮".codePointAt(0) - "a".codePointAt(0);
+import punycode from '../node_modules/punycode/punycode.es6.js';
 
-const isUpper = (n) => n >= 65 && n < 91;
-const isLower = (n) => n >= 97 && n < 123;
+const encode = (charCode) => punycode.ucs2.encode([charCode]);
+const decode = (char) => punycode.ucs2.decode(char)[0];
+
+const UPPERCASE_A = decode("A");
+const UPPERCASE_Z = decode("Z");
+const LOWERCASE_A = decode("a");
+const LOWERCASE_Z = decode("z");
+const BOLD_UPPERCASE_A = decode("𝗔");
+const BOLD_UPPERCASE_Z = decode("𝗭");
+const BOLD_LOWERCASE_A = decode("𝗮");
+const BOLD_LOWERCASE_Z = decode("𝘇");
+
+
+const UPPERCASE_DIFF = BOLD_UPPERCASE_A - UPPERCASE_A;
+const LOWERCASE_DIFF = BOLD_LOWERCASE_A - LOWERCASE_A;
+const NUMBER_DIFF = 0x1D79E;
+
+const isUpper = (n) => n >= UPPERCASE_A && n <= UPPERCASE_Z;
+const isLower = (n) => n >= LOWERCASE_A && n <= LOWERCASE_Z;
+const isUpperBold = (n) => n >= BOLD_UPPERCASE_A && n <= BOLD_UPPERCASE_Z;
+const isLowerBold = (n) => n >= BOLD_LOWERCASE_A && n <= BOLD_LOWERCASE_Z;
 
 const bolderize = (char) => {
-  const n = char.charCodeAt(0);
-  if (isUpper(n)) return String.fromCodePoint(n + upperDiff);
-  if (isLower(n)) return String.fromCodePoint(n + lowerDiff);
+  const n = decode(char);
+
+  if (isUpper(n)) return encode(n + UPPERCASE_DIFF);
+  if (isLower(n)) return encode(n + LOWERCASE_DIFF);
+
   return char;
 };
 
-function bolderizeNumbers(text) {
-  return text.replace(/\d/g, (c) => String.fromCodePoint(0x1D79E + c.charCodeAt(0)));
+const unbolderize = (char) => {
+  const n = decode(char);
+
+  if (isUpperBold(n)) return encode(n - UPPERCASE_DIFF);
+  if (isLowerBold(n)) return encode(n - LOWERCASE_DIFF);
+
+  return char;
 }
 
-export const bolderizeWord = (word) => bolderizeNumbers([...word].map(bolderize).join(""));
+const bolderizeNumbers = (text) => {
+  return text.replace(/\d/g, (c) => encode([decode(c) + NUMBER_DIFF]));
+}
+
+const unbolderizeNumbers = (text) => {
+  return text.replace(/\d/g, (c) => encode([decode(c) - NUMBER_DIFF]));
+}
+
+const bolderizeWord = (word) => bolderizeNumbers([...word].map(bolderize).join(""));
+const unbolderizeWord = (word) => unbolderizeNumbers([...word].map(unbolderize).join(""));
+
+export const bolderizeOrUnbolderizeWord = (text) => {
+  const hasUnbolderizedCharacters = !!text.match(/[A-Za-z0-9]/g);
+  return hasUnbolderizedCharacters ? bolderizeWord(text) : unbolderizeWord(text);
+}


### PR DESCRIPTION
- Changed character encoding/decoding method as JS's functions don't cover newer characters properly.
- Shuffled some code for easy setup of text transformation tests.
- In order to use ES6 exports in browser and without building, node_modules is no longer ignored by Babel.